### PR TITLE
use dynamodb remote state locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ After installing AWS CLI, configure it with your AWS credentials by running the 
 
 ### Intro
 
+
+
 Terraform template to setup simple cluster
 
 ### Deploy infra
@@ -28,6 +30,8 @@ Terraform template to setup simple cluster
 # change count for mgmt_nodes and storage_nodes variables in variables.tf
 
 # review the resources
+terraform init
+
 terraform plan
 
 terraform init
@@ -37,7 +41,7 @@ terraform apply -var namespace="csi" -var mgmt_nodes=1 -var storage_nodes=3 --au
 # Deploying with eks
 terraform apply -var namespace="csi" -var mgmt_nodes=1 -var storage_nodes=3 -var enable_eks=1 --auto-approve
 
-# Specifying the instance types to use 
+# Specifying the instance types to use
 terraform apply -var namespace="csi" -var mgmt_nodes=1 -var storage_nodes=3 \
                 -var mgmt_nodes_instance_type="m5.large" -var storage_nodes_instance_type="m5.large" --auto-approve
 
@@ -56,7 +60,7 @@ terraform apply -var namespace="csi" -var mgmt_nodes=1 -var storage_nodes=3 -var
 chmod +x ./bootstrap-cluster.sh
 ./bootstrap-cluster.sh
 
-# To see supported option 
+# To see supported option
 ./bootstrap-cluster.sh --help
 
 # specifying cluster argument to use
@@ -64,7 +68,12 @@ chmod +x ./bootstrap-cluster.sh
 ```
 ### Destroy Cluster
 ```
-terraform apply -var mgmt_nodes=0 -var storage_nodes=0 --auto-approve
+terraform apply -var namespace="csi" -var mgmt_nodes=0 -var storage_nodes=0 --auto-approve
+```
+
+or you could destroy all the resources created
+```
+terraform destory --auto-approve
 ```
 
 

--- a/main.tf
+++ b/main.tf
@@ -3,14 +3,13 @@ provider "aws" {
 }
 
 terraform {
-  # backend "s3" {
-  #   bucket = "simplyblock-terraform-state-bucket"
-  #   key    = "csi"
-  #   region = "us-east-2"
-  #   # dynamodb_table = "terraform-up-and-running-locks"
-  #   encrypt = true
-  # }
-  backend "local" {}
+  backend "s3" {
+    bucket = "simplyblock-terraform-state-bucket"
+    key    = "csi"
+    region = "us-east-2"
+    dynamodb_table = "terraform-up-and-running-locks"
+    encrypt = true
+  }
 }
 
 data "aws_availability_zones" "available" {
@@ -33,7 +32,7 @@ data "aws_secretsmanager_secret_version" "simply" {
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
 
-  name = "${var.namespace}-sb-storage-vpc"
+  name = "${var.namespace}-storage-vpc-sb"
   cidr = "10.0.0.0/16"
 
   azs                     = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1], ]


### PR DESCRIPTION
A way to use global state. So that others can destroy the cluster if the one of is not active. 