### PR TITLE
fix cluster-bootstrap.sh: cluster iteration

### DIFF
--- a/bootstrap-cluster.sh
+++ b/bootstrap-cluster.sh
@@ -106,7 +106,7 @@ echo ""
 echo "Adding other management nodes if they exist.."
 echo ""
 
-for ((i = 2; i <= $#mnodes; i++)); do
+for ((i = 2; i <= ${#mnodes[@]}; i++)); do
     echo ""
     echo "Adding mgmt node ${i}.."
     echo ""


### PR DESCRIPTION
Currently I get this error when I use the boostrap-cluster.sh 

```
./bootstrap-cluster.sh: line 109: ((: i <= 0mnodes: value too great for base (error token is "0mnodes")
Warning: Permanently added '44.200.54.248' (ED25519) to the list of known hosts.
00.1e.0

^C
```

@geoffrey1330 can you try this fix from your end also the github actions and see if it works. 

