### PR TITLE
tf outputs: storage node public IPs

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -45,12 +45,12 @@ variable "extra_nodes" {
 
 variable "mgmt_nodes_instance_type" {
   default = "m5.large"
-  type    = string 
+  type    = string
 }
 
 variable "storage_nodes_instance_type" {
   default = "m5.large"
-  type    = string 
+  type    = string
 }
 
 variable "extra_nodes_instance_type" {
@@ -78,7 +78,11 @@ variable "volumes_per_storage_nodes" {
 }
 
 variable "nr_hugepages" {
-  default = 2048
+  default     = 2048
   description = "number of huge pages"
-  type    = number
+  type        = number
+}
+
+output "storage_public_ips" {
+  value = join(" ", [for inst in aws_instance.storage_nodes : inst.public_ip])
 }


### PR DESCRIPTION
to fix the error: 

```
Directory /Users/manohar/.ssh already exists.
the ssh key: /Users/manohar/.ssh/simplyblock-us-east-1.pem already exits on local
╷
│ Error: Output "storage_public_ips" not found
│
│ The output variable requested could not be found in the state file. If you recently added this to your configuration, be sure to run `terraform apply`, since the state
│ won't be updated with new output variables until that command is run.
╵
bootstrapping cluster...
```