### PR TITLE
allow port 80 in security group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,6 +65,14 @@ resource "aws_security_group" "container_inst_sg" {
   }
 
   ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = var.whitelist_ips
+    description = "access the mgmt node from the bootstrap script"
+  }
+
+  ingress {
     from_port = 0
     to_port   = 0
     protocol  = -1


### PR DESCRIPTION
Deployer requires access to the mgmt node public IP

```
% Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:50 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:02:10 --:--:--     0
curl: (28) Failed to connect to 18.191.106.167 port 80: Connection timed out
Cluster ID is:
usage: sbcli-dev cluster unsuspend [-h] cluster_id
sbcli-dev cluster unsuspend: error: the following arguments are required: cluster_id

```