### PR TITLE
service discovery endpoint

### DIFF
--- a/api.tf
+++ b/api.tf
@@ -35,6 +35,8 @@ resource "aws_service_discovery_service" "root_service" {
 }
 
 resource "aws_service_discovery_instance" "root_endpoint" {
+  count = length(aws_instance.mgmt_nodes) > 0 ? 1 : 0
+
   instance_id = aws_instance.mgmt_nodes[0].id
   service_id  = aws_service_discovery_service.root_service.id
 

--- a/grafana.tf
+++ b/grafana.tf
@@ -25,6 +25,8 @@ resource "aws_service_discovery_service" "grafana_service" {
 }
 
 resource "aws_service_discovery_instance" "grafana_endpoint" {
+  count = length(aws_instance.mgmt_nodes) > 0 ? 1 : 0
+
   instance_id = aws_instance.mgmt_nodes[0].id
   service_id  = aws_service_discovery_service.grafana_service.id
 


### PR DESCRIPTION
todo: 

At the moment, `terraform destroy` is not removing the resources created in API Gateway and AWS Cloud Map. Need to check this. 
