### PR TITLE
use e2e dev tag for e2e tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -49,7 +49,11 @@ jobs:
         run: terraform validate
 
       - name: Plan Terraform Changes
-        run: terraform plan -var "namespace=github-action" -var "mgmt_nodes=1" -var "storage_nodes=3" -var "extra_nodes=1" -var "extra_nodes_instance_type=m6id.large" -out=tfplan
+        run: |
+          terraform plan -var "namespace=github-action" \
+            -var "mgmt_nodes=1" -var "storage_nodes=3" \
+            -var "extra_nodes=1" -var "extra_nodes_instance_type=m6id.large" \
+            -var "region=us-east-2" -out=tfplan
 
       - name: Apply Terraform Changes
         run: terraform apply tfplan
@@ -91,8 +95,9 @@ jobs:
              --set csiConfig.simplybk.uuid=${{ steps.bootstrap_cluster.outputs.cluster_id }} \
              --set csiConfig.simplybk.ip=${{ steps.bootstrap_cluster.outputs.cluster_api_gateway_endpoint }} \
              --set csiSecret.simplybk.secret=${{ steps.bootstrap_cluster.outputs.cluster_secret }} \
-             --set logicalVolume.pool_name=testing1
-             
+             --set logicalVolume.pool_name=testing1 \
+             --set image.simplyblock.tag=dev
+
       - name: Run tests
         run: |
           cd spdk-csi


### PR DESCRIPTION
With the changes in the PR: https://github.com/simplyblock-io/spdk-csi/pull/33, the default tag that will be used is `release_v1` but as a part of e2e tests, we should be using `dev` so that changes merged to `sbcli-dev` is used all the time. 

Updating the e2e tests to use the dev tag