### PR TITLE
Fix env variable

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -68,7 +68,7 @@ jobs:
           terraform plan \
             -var "mgmt_nodes=1" -var "storage_nodes=3" \
             -var "extra_nodes=1" -var "extra_nodes_instance_type=m6id.large" \
-            -var "region=us-east-2" -var "sbcli_pkg=${{ github.event.inputs.sbcli_cmd || 'sbcli-dev' }}" -out=tfplan
+            -var "region=us-east-2" -var "sbcli_cmd=${{ github.event.inputs.sbcli_cmd || 'sbcli-dev' }}" -out=tfplan
 
       - name: Apply Terraform Changes
         run: terraform apply tfplan


### PR DESCRIPTION
```
│ Error: Value for undeclared variable
│ 
│ A variable named "sbcli_pkg" was assigned on the command line, but the root
│ module does not declare a variable of that name. To use this value, add a
│ "variable" block to the configuration.
```