### PR TITLE
fail the script if we see errors

### DIFF
--- a/bootstrap-cluster.sh
+++ b/bootstrap-cluster.sh
@@ -121,6 +121,9 @@ while true; do
     if [[ "$dstatus" == "status: done" ]]; then
         echo "Cloud-init is done. Exiting loop."
         break
+    elif [[ "$dstatus" == "status: error" ]]; then
+        echo "Cloud-init has failed"
+        exit 1
     fi
 
     echo "Waiting for cloud-init to finish..."


### PR DESCRIPTION
This Github Action is stuck with this error.

```
Current status: status: error
Waiting for cloud-init to finish...
Current status: status: error
Waiting for cloud-init to finish...
Current status: status: error
Waiting for cloud-init to finish...
```

https://github.com/simplyblock-io/sbcli/actions/runs/9467644365/job/26082140024

This could fix the issue