### PR TITLE
select workspace and then terraform init

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -54,6 +54,12 @@ jobs:
           chmod 700 get_helm.sh
           ./get_helm.sh
 
+      - name: select or create workspace
+        run: terraform workspace select -or-create githubactions
+
+      - name: Validate Terraform Configuration
+        run: terraform validate
+
       - name: Initialize Terraform
         run: |
           export TFSTATE_BUCKET=simplyblock-terraform-state-bucket
@@ -67,12 +73,6 @@ jobs:
             -backend-config="region=${TFSTATE_REGION}" \
             -backend-config="dynamodb_table=${TFSTATE_DYNAMODB_TABLE}" \
             -backend-config="encrypt=true"
-
-      - name: select or create workspace
-        run: terraform workspace select -or-create githubactions
-
-      - name: Validate Terraform Configuration
-        run: terraform validate
 
       - name: Plan Terraform Changes
         run: |


### PR DESCRIPTION
to prevent error during state init like: 

```
╷
│ Error: Error refreshing state: state data in S3 does not have the expected content.
│
│ The checksum calculated for the state stored in S3 does not match the checksum
│ stored in DynamoDB.
│
│ Bucket: simplyblock-terraform-state-bucket
│ Key:    csi
│ Calculated checksum: d1bcd5e01054b9bc67a1a5217209e1e7
│ Stored checksum:     58bc0497cd3fd0d9aced47c45ebab3d3
│
│ This may be caused by unusually long delays in S3 processing a previous state
│ update. Please wait for a minute or two and try again.
│
│ If this problem persists, and neither S3 nor DynamoDB are experiencing an
│ outage, you may need to manually verify the remote state and update the Digest
│ value stored in the DynamoDB table to the following value: d1bcd5e01054b9bc67a1a5217209e1e7
```