### PR TITLE
tf engine logs bucket force destroy

### DIFF
--- a/tfengine.tf
+++ b/tfengine.tf
@@ -113,7 +113,8 @@ resource "random_id" "id" {
 
 # A bucket for store terraform execution output logs
 resource "aws_s3_bucket" "tfengine_logs" {
-  bucket = "simplyblock-tfengine-logs-${random_id.id.hex}"
+  bucket        = "simplyblock-tfengine-logs-${random_id.id.hex}"
+  force_destroy = true
 }
 
 # A policy to allow the instance to put logs in the bucket


### PR DESCRIPTION
currently we get this error during destroy 

```
│ Error: deleting S3 Bucket (simplyblock-tfengine-logs-320462a61f): operation error S3: DeleteBucket, https response error StatusCode: 409, RequestID: 2BABJGTE2D9T9KCG, HostID: vuHzhTiNIl72aL/7/etN9NVLwf2VT9NW8n3kVG2uEqg1ZxhoEnmBbKF6vXFskxQ6+FO5XRNStGrOTvsJk+rxb4NloN/nt/X6, api error BucketNotEmpty: The bucket you tried to delete is not empty
│ 
│ 
╵
```