### PR TITLE
use workspace for tfengine instance

### DIFF
--- a/tfengine.tf
+++ b/tfengine.tf
@@ -67,7 +67,7 @@ EOF
     resource_type = "instance"
 
     tags = {
-      Name = "tfengine"
+      Name = "${terraform.workspace}-tfengine"
     }
   }
 }


### PR DESCRIPTION
currently we are using the same name "tfengine" for all the deployment. 

This is causing an issue where when the command is applied, it tried to run the command on the all instances. But with terraform, one instance of terraform command should running at any time. 

To maintain the uniqueness in the instance name, using workspace to maintain. 

<img width="1066" alt="Screenshot 2024-07-08 at 22 11 01" src="https://github.com/simplyblock-io/simplyBlockDeploy/assets/9148277/5ae42277-eb66-4f42-8a5b-86fc0dcc4432">
