### PR TITLE
adding aws provider version

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -1,7 +1,14 @@
 provider "aws" {
   region = var.region
+
 }
 
 terraform {
   backend "s3" {}
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = ">= 5.70.0"
+    }
+  }
 }


### PR DESCRIPTION
https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md
 
according to terraform aws provider changelog :

This Terraform AWS Provider version has been removed from the [Terraform Registry](https://registry.terraform.io/providers/hashicorp/aws/latest) due to archive has incorrect checksum errors while installing the provider.