### PR TITLE
AWS install based on machine architecture

### DIFF
--- a/upload_docker_logs_to_s3.sh
+++ b/upload_docker_logs_to_s3.sh
@@ -62,7 +62,6 @@ else
 fi
 unzip awscliv2.zip
 sudo ./aws/install --update
-sudo rm -rf /usr/local/aws-cli /usr/local/bin/aws awscliv2.zip aws
 
 aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
 aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
For dockerswarm:
s3://simplyblock-e2e-test-logs/12085859174/
Github run: https://github.com/simplyblock-io/sbcli/actions/runs/12085859174/
For k8s:
s3://simplyblock-e2e-test-logs/12084776240/
Github run: https://github.com/simplyblock-io/sbcli/actions/runs/12084776240

Deployer e2e:
s3://simplyblock-e2e-test-logs/12086579946/
Github run: https://github.com/simplyblock-io/simplyBlockDeploy/actions/runs/12086579946/