### PR TITLE
Use sbcli branch

### DIFF
--- a/bootstrap-cluster.sh
+++ b/bootstrap-cluster.sh
@@ -57,6 +57,8 @@ IOBUF_LARGE_BUFFSIZE=""
 LOG_DEL_INTERVAL=""
 METRICS_RETENTION_PERIOD=""
 SBCLI_CMD="${SBCLI_CMD:-sbcli-dev}"
+SBCLI_INSTALL_SOURCE="${SBCLI_BRANCH:+git+https://github.com/simplyblock-io/sbcli.git@${SBCLI_BRANCH}}"
+SBCLI_INSTALL_SOURCE="${SBCLI_INSTALL_SOURCE:-${SBCLI_CMD}}"
 SPDK_IMAGE=""
 CPU_MASK=""
 CONTACT_POINT=""
@@ -243,7 +245,7 @@ for node_ip in ${storage_private_ips}; do
             pip uninstall -y \$old_pkg
         fi
         sudo sysctl -w vm.nr_hugepages=${nr_hugepages}
-        pip install ${SBCLI_CMD} --upgrade
+        pip install ${SBCLI_INSTALL_SOURCE} --upgrade
         if [ "$K8S_SNODE" == "true" ]; then
             :  # Do nothing
         else
@@ -263,7 +265,7 @@ for node_ip in ${sec_storage_private_ips}; do
             pip uninstall -y \$old_pkg
         fi
         sudo sysctl -w vm.nr_hugepages=${nr_hugepages}
-        pip install ${SBCLI_CMD} --upgrade
+        pip install ${SBCLI_INSTALL_SOURCE} --upgrade
         if [ "$K8S_SNODE" == "true" ]; then
             :  # Do nothing
         else
@@ -282,7 +284,7 @@ for node_ip in ${mnodes[@]}; do
             \$old_pkg sn deploy-cleaner
             pip uninstall -y \$old_pkg
         fi
-        pip install ${SBCLI_CMD} --upgrade
+        pip install ${SBCLI_INSTALL_SOURCE} --upgrade
     "
 done
 


### PR DESCRIPTION
before running bootstrap cluster script, just export `SBCLI_BRANCH=<branch-name>`. This will pull latest image. You don't have to env_var file.

Tested by creating a cluster 
<img width="804" alt="Screenshot 2025-05-06 at 07 22 34" src="https://github.com/user-attachments/assets/3dd6c4fb-c31c-4f30-90e3-bdb47352d5a7" />

