### PR TITLE
Use idiomatic way of GitHub output

### DIFF
--- a/bootstrap-cluster.sh
+++ b/bootstrap-cluster.sh
@@ -388,9 +388,9 @@ main() {
     add_storage_nodes
     add_pool
 
-    echo "::set-output name=cluster_id::$CLUSTER_ID"
-    echo "::set-output name=cluster_secret::$CLUSTER_SECRET"
-    echo "::set-output name=cluster_ip::http://${mnodes[0]}"
+    echo "cluster_id=$CLUSTER_ID" >> ${GITHUB_OUTPUT:-/dev/stdout}
+    echo "cluster_secret=$CLUSTER_SECRET" >> ${GITHUB_OUTPUT:-/dev/stdout}
+    echo "cluster_ip=http://${mnodes[0]}" >> ${GITHUB_OUTPUT:-/dev/stdout}
     echo "Successfully deployed the cluster"
 }
 

--- a/bootstrap-k3s.sh
+++ b/bootstrap-k3s.sh
@@ -39,8 +39,8 @@ IFS=' ' read -ra mnodes <<<"$mnodes"
 storage_private_ips=$STORAGE_PRIVATE_IPS
 sec_storage_private_ips=$SEC_STORAGE_PRIVATE_IPS
 
-echo "::set-output name=KEY::$KEY"
-echo "::set-output name=extra_node_ip::${mnodes[0]}"
+echo "KEY=$KEY" >> ${GITHUB_OUTPUT:-/dev/stdout}
+echo "extra_node_ip=${mnodes[0]}" >> ${GITHUB_OUTPUT:-/dev/stdout}
 
 
 echo "cleaning up old K8s cluster..."


### PR DESCRIPTION
The way outputs are handled in GitHub workflows changed recently: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

The changes will use the current idiomatic way, falling back to printing to stdout if the GitHub specific variable is not defined.