### PR TITLE
update storage node label key

### DIFF
--- a/aws/bootstrap-k3s.sh
+++ b/aws/bootstrap-k3s.sh
@@ -189,7 +189,7 @@ if [ "$K8S_SNODE" == "true" ]; then
         "
 
         NODE_NAME=$(ssh -i $KEY -o StrictHostKeyChecking=no ec2-user@${mnodes[0]} "kubectl get nodes -o wide | grep -w ${node} | awk '{print \$1}'")
-        ssh -i $KEY -o StrictHostKeyChecking=no ec2-user@${mnodes[0]} "kubectl label nodes $NODE_NAME type=simplyblock-storage-plane --overwrite"
+        ssh -i $KEY -o StrictHostKeyChecking=no ec2-user@${mnodes[0]} "kubectl label nodes $NODE_NAME io.simplyblock.node-type=simplyblock-storage-plane --overwrite"
     done
 
     for node in ${sec_storage_private_ips[@]}; do
@@ -225,6 +225,6 @@ if [ "$K8S_SNODE" == "true" ]; then
         "
 
         NODE_NAME=$(ssh -i $KEY -o StrictHostKeyChecking=no ec2-user@${mnodes[0]} "kubectl get nodes -o wide | grep -w ${node} | awk '{print \$1}'")
-        ssh -i $KEY -o StrictHostKeyChecking=no ec2-user@${mnodes[0]} "kubectl label nodes $NODE_NAME type=simplyblock-storage-plane-reserve --overwrite"
+        ssh -i $KEY -o StrictHostKeyChecking=no ec2-user@${mnodes[0]} "kubectl label nodes $NODE_NAME io.simplyblock.node-type=simplyblock-storage-plane-reserve --overwrite"
     done
 fi

--- a/aws/eks.tf
+++ b/aws/eks.tf
@@ -193,7 +193,7 @@ module "eks" {
         lockdown = "integrity"
 
         [settings.kubernetes.node-labels]
-        type = "simplyblock-storage-plane"
+        io.simplyblock.node-type = "simplyblock-storage-plane"
 
         [settings.kubernetes.node-taints]
         dedicated = "experimental:PreferNoSchedule"
@@ -213,7 +213,7 @@ module "eks" {
       max_size     = 3
 
       labels = {
-        type = "simplyblock-storage-plane"
+        io.simplyblock.node-type = "simplyblock-storage-plane"
       }
 
       taints = {

--- a/bare-metal/bootstrap-k3s.sh
+++ b/bare-metal/bootstrap-k3s.sh
@@ -198,7 +198,7 @@ if [ "$K8S_SNODE" == "true" ]; then
         "
 
         NODE_NAME=$(ssh -i $KEY -o StrictHostKeyChecking=no root@${mnodes[0]} "kubectl get nodes -o wide | grep -w ${node} | awk '{print \$1}'")
-        ssh -i $KEY -o StrictHostKeyChecking=no root@${mnodes[0]} "kubectl label nodes $NODE_NAME type=simplyblock-storage-plane --overwrite"
+        ssh -i $KEY -o StrictHostKeyChecking=no root@${mnodes[0]} "kubectl label nodes $NODE_NAME io.simplyblock.node-type =simplyblock-storage-plane --overwrite"
     done
 
     for node in ${sec_storage_private_ips[@]}; do
@@ -231,6 +231,6 @@ if [ "$K8S_SNODE" == "true" ]; then
         "
 
         NODE_NAME=$(ssh -i $KEY -o StrictHostKeyChecking=no root@${mnodes[0]} "kubectl get nodes -o wide | grep -w ${node} | awk '{print \$1}'")
-        ssh -i $KEY -o StrictHostKeyChecking=no root@${mnodes[0]} "kubectl label nodes $NODE_NAME type=simplyblock-storage-plane-reserve --overwrite"
+        ssh -i $KEY -o StrictHostKeyChecking=no root@${mnodes[0]} "kubectl label nodes $NODE_NAME io.simplyblock.node-type =simplyblock-storage-plane-reserve --overwrite"
     done
 fi


### PR DESCRIPTION
Simplyblock Kubernetes label just use “type” as the key. It is possible that this key could conflict with other keys in customers environment. So 

Using the new key as:
```
io.simplyblock.node-type=simplyblock-storage-plane
```