### PR TITLE
Avoid expensive operations during K3S

### DIFF
--- a/bare-metal/bootstrap-k3s.sh
+++ b/bare-metal/bootstrap-k3s.sh
@@ -56,12 +56,6 @@ for node_ip in ${mnodes[@]}; do
             echo "Uninstalling k3s..."
             /usr/local/bin/k3s-uninstall.sh
         fi
-
-        # Remove installed packages
-        echo "Removing installed packages..."
-        sudo yum remove -y fio nvme-cli make golang
-
-        sleep 10 
     "
 done
 
@@ -74,12 +68,6 @@ for node_ip in ${storage_private_ips}; do
             echo "Uninstalling k3s..."
             /usr/local/bin/k3s-uninstall.sh
         fi
-
-        # Remove installed packages
-        echo "Removing installed packages..."
-        sudo yum remove -y fio nvme-cli make golang
-
-        sleep 10 
     "
 done
 
@@ -92,12 +80,6 @@ for node_ip in ${sec_storage_private_ips}; do
             echo "Uninstalling k3s..."
             /usr/local/bin/k3s-uninstall.sh
         fi
-
-        # Remove installed packages
-        echo "Removing installed packages..."
-        sudo yum remove -y fio nvme-cli make golang
-
-        sleep 10 
     "
 done
 


### PR DESCRIPTION
This PR removes uninstallation of required packages from the bootstrapping process, as well as waiting after each of the operations.