### PR TITLE
fix node label key for aws terraform

### DIFF
--- a/aws/eks.tf
+++ b/aws/eks.tf
@@ -193,7 +193,7 @@ module "eks" {
         lockdown = "integrity"
 
         [settings.kubernetes.node-labels]
-        io.simplyblock.node-type = "simplyblock-storage-plane"
+        "io.simplyblock.node-type" = "simplyblock-storage-plane"
 
         [settings.kubernetes.node-taints]
         dedicated = "experimental:PreferNoSchedule"
@@ -213,7 +213,7 @@ module "eks" {
       max_size     = 3
 
       labels = {
-        io.simplyblock.node-type = "simplyblock-storage-plane"
+        "io.simplyblock.node-type" = "simplyblock-storage-plane"
       }
 
       taints = {


### PR DESCRIPTION
PR https://github.com/simplyblock-io/simplyBlockDeploy/pull/194 introduced change to the label key name. 

but upon terraform apply the following error is returned:

```
 A managed resource "io" "simplyblock" has not been declared in the root module.
```