### PR TITLE
Add --max-lvol as alias for --max-subsys in parse_args

### DIFF
--- a/bare-metal/bootstrap-cluster.sh
+++ b/bare-metal/bootstrap-cluster.sh
@@ -118,7 +118,7 @@ EXTRA_CLUSTER_ARGS=()
 while [[ $# -gt 0 ]]; do
     arg="$1"
     case $arg in
-    --max-subsys)
+    --max-subsys|--max-lvol)
         MAX_SUBSYS="$2"
         shift
         ;;


### PR DESCRIPTION
Backward compat for workflows still using the old flag name.